### PR TITLE
fix: missing build tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/node": "^14.14.44",
     "@typescript-eslint/eslint-plugin": "^4.22.1",
     "@typescript-eslint/parser": "^4.22.1",
+    "@vercel/ncc": "^0.28.5",
     "axios-mock-adapter": "^1.19.0",
     "eslint": "^7.25.0",
     "eslint-config-prettier": "8.3.0",


### PR DESCRIPTION
```
$ npm-run-all clean tsc ; ncc build dist0/index.js --license licenses.txt
$ rimraf dist/*
$ tsc
/bin/sh: ncc: command not found
error Command failed with exit code 127.
```