### PR TITLE
add: fileName can be specified in settings.json

### DIFF
--- a/sample-settings/ever-green.json
+++ b/sample-settings/ever-green.json
@@ -1,5 +1,6 @@
 {
   "type": "normal",
+  "fileName": "profile-custom-evergreen.svg",
   "backgroundColor": "#ffffff",
   "foregroundColor": "#00000f",
   "strongColor": "#111133",

--- a/sample-settings/gitblock.json
+++ b/sample-settings/gitblock.json
@@ -1,5 +1,6 @@
 {
   "type": "bitmap",
+  "fileName": "profile-custom-gitblock.svg",
   "backgroundColor": "#ffffff",
   "foregroundColor": "#00000f",
   "strongColor": "#111133",

--- a/sample-settings/rainbow.json
+++ b/sample-settings/rainbow.json
@@ -1,5 +1,6 @@
 {
   "type": "rainbow",
+  "fileName": "profile-custom-rainbow.svg",
   "backgroundColor": "#00000f",
   "foregroundColor": "#eeeeff",
   "strongColor": "rgb(255,200,55)",

--- a/sample-settings/season.json
+++ b/sample-settings/season.json
@@ -1,5 +1,6 @@
 {
   "type": "season",
+  "fileName": "profile-custom-season.svg",
   "backgroundColor": "#ffffff",
   "foregroundColor": "#00000f",
   "strongColor": "#111133",

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,8 @@ export const main = async (): Promise<void> => {
 
         if (process.env.SETTING_JSON) {
             const settings = r.readSettingJson(process.env.SETTING_JSON);
-            f.writeFile(
-                'profile-customize.svg',
-                create.createSvg(userInfo, settings, false)
-            );
+            const fileName = settings.fileName || 'profile-customize.svg';
+            f.writeFile(fileName, create.createSvg(userInfo, settings, false));
         } else {
             const settings = userInfo.isHalloween
                 ? template.HalloweenSettings

--- a/src/type.ts
+++ b/src/type.ts
@@ -31,25 +31,25 @@ export type ContributionLevel =
     | 'THIRD_QUARTILE'
     | 'FOURTH_QUARTILE';
 
-export interface NormalColorSettings {
-    type: 'normal';
+interface BaseSettings {
     backgroundColor: string;
     foregroundColor: string;
     strongColor: string;
     weakColor: string;
     radarColor: string;
+
+    fileName?: string;
+}
+
+export interface NormalColorSettings extends BaseSettings {
+    type: 'normal';
     growingAnimation?: boolean;
 
     contribColors: [string, string, string, string, string];
 }
 
-export interface SeasonColorSettings {
+export interface SeasonColorSettings extends BaseSettings {
     type: 'season';
-    backgroundColor: string;
-    foregroundColor: string;
-    strongColor: string;
-    weakColor: string;
-    radarColor: string;
     growingAnimation?: boolean;
 
     /** first season (Mar. - Jun.) */
@@ -62,13 +62,8 @@ export interface SeasonColorSettings {
     contribColors4: [string, string, string, string, string];
 }
 
-export interface RainbowColorSettings {
+export interface RainbowColorSettings extends BaseSettings {
     type: 'rainbow';
-    backgroundColor: string;
-    foregroundColor: string;
-    strongColor: string;
-    weakColor: string;
-    radarColor: string;
     growingAnimation?: boolean;
 
     saturation: string;
@@ -101,13 +96,8 @@ export interface ContribPattern {
     right: SidePanelPattern;
 }
 
-export interface BitmapPatternSettings {
+export interface BitmapPatternSettings extends BaseSettings {
     type: 'bitmap';
-    backgroundColor: string;
-    foregroundColor: string;
-    strongColor: string;
-    weakColor: string;
-    radarColor: string;
     growingAnimation?: boolean;
 
     contribPatterns: [


### PR DESCRIPTION
Enabled to specify the output destination file name when using settings json.

See `sample-settings/*.json` and `src/type.ts` for details.

```diff
  {
    "type": "normal",
+   "fileName": "profile-custom-evergreen.svg",
    "backgroundColor": "#ffffff",
    "foregroundColor": "#00000f",
    "strongColor": "#111133",
    "weakColor": "gray",
    "radarColor": "#47a042",
    "growingAnimation": true,
    "contribColors": [
      "#efefef",
      "#d8e887",
      "#8cc569",
      "#47a042",
      "#1d6a23"
    ]
}
```