### PR TITLE
add: enabled multiple custom outputs

### DIFF
--- a/sample-settings/multiple.json
+++ b/sample-settings/multiple.json
@@ -1,0 +1,39 @@
+[
+  {
+    "type": "normal",
+    "fileName": "profile-custom-evergreen.svg",
+    "backgroundColor": "#ffffff",
+    "foregroundColor": "#00000f",
+    "strongColor": "#111133",
+    "weakColor": "gray",
+    "radarColor": "#47a042",
+    "growingAnimation": true,
+    "contribColors": [
+      "#efefef",
+      "#d8e887",
+      "#8cc569",
+      "#47a042",
+      "#1d6a23"
+    ]
+  },
+  {
+    "type": "rainbow",
+    "fileName": "profile-custom-rainbow.svg",
+    "backgroundColor": "#00000f",
+    "foregroundColor": "#eeeeff",
+    "strongColor": "rgb(255,200,55)",
+    "weakColor": "#aaaaaa",
+    "radarColor": "rgb(255,200,55)",
+    "growingAnimation": true,
+    "saturation": "50%",
+    "contribLightness": [
+      "20%",
+      "30%",
+      "35%",
+      "40%",
+      "50%"
+    ],
+    "duration": "10s",
+    "hueRatio": -7
+  }
+]

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,17 @@ export const main = async (): Promise<void> => {
         const userInfo = aggregate.aggregateUserInfo(response);
 
         if (process.env.SETTING_JSON) {
-            const settings = r.readSettingJson(process.env.SETTING_JSON);
-            const fileName = settings.fileName || 'profile-customize.svg';
-            f.writeFile(fileName, create.createSvg(userInfo, settings, false));
+            const settingFile = r.readSettingJson(process.env.SETTING_JSON);
+            const settingInfos =
+                'length' in settingFile ? settingFile : [settingFile];
+            for (const settingInfo of settingInfos) {
+                const fileName =
+                    settingInfo.fileName || 'profile-customize.svg';
+                f.writeFile(
+                    fileName,
+                    create.createSvg(userInfo, settingInfo, false)
+                );
+            }
         } else {
             const settings = userInfo.isHalloween
                 ? template.HalloweenSettings

--- a/src/settings-reader.ts
+++ b/src/settings-reader.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import * as type from './type';
 
-export const readSettingJson = (filePath: string): type.Settings => {
+export const readSettingJson = (filePath: string): type.SettingFile => {
     const content = readFileSync(filePath, {
         encoding: 'utf8',
         flag: 'r',

--- a/src/type.ts
+++ b/src/type.ts
@@ -114,3 +114,5 @@ export type Settings =
     | SeasonColorSettings
     | RainbowColorSettings
     | BitmapPatternSettings;
+
+export type SettingFile = Settings | Settings[];


### PR DESCRIPTION
One or more custom definitions can be specified.

See `sample-settings/multiple.json`