### PR TITLE
add: L10N label in settings json

### DIFF
--- a/sample-settings/spanish.json
+++ b/sample-settings/spanish.json
@@ -1,0 +1,25 @@
+{
+  "type": "normal",
+  "fileName": "profile-custom-spanish.svg",
+  "backgroundColor": "#ffffff",
+  "foregroundColor": "#00000f",
+  "strongColor": "#111133",
+  "weakColor": "gray",
+  "radarColor": "#47a042",
+  "growingAnimation": true,
+  "contribColors": [
+    "#efefef",
+    "#d8e887",
+    "#8cc569",
+    "#47a042",
+    "#1d6a23"
+  ],
+  "l10n": {
+    "commit": "Commit",
+    "repo": "Repositorios",
+    "review": "Revisiones",
+    "pullreq": "Pull/Req",
+    "issue": "Issues",
+    "contrib": "contribuciones"
+  }
+}

--- a/src/create-radar-contrib.ts
+++ b/src/create-radar-contrib.ts
@@ -28,25 +28,31 @@ export const createRadarContrib = (
     const cx = width / 2;
     const cy = (height / 2) * 1.1;
 
+    const commitLabel = settings.l10n ? settings.l10n.commit : 'Commit';
+    const issueLabel = settings.l10n ? settings.l10n.issue : 'Issue';
+    const pullReqLabel = settings.l10n ? settings.l10n.pullreq : 'PullReq';
+    const reviewLabel = settings.l10n ? settings.l10n.review : 'Review';
+    const RepoLabel = settings.l10n ? settings.l10n.repo : 'Repo';
+
     const data = [
         {
-            name: 'Commit',
+            name: commitLabel,
             value: userInfo.totalCommitContributions,
         },
         {
-            name: 'Issue',
+            name: issueLabel,
             value: userInfo.totalIssueContributions,
         },
         {
-            name: 'PullReq',
+            name: pullReqLabel,
             value: userInfo.totalPullRequestContributions,
         },
         {
-            name: 'Review',
+            name: reviewLabel,
             value: userInfo.totalPullRequestReviewContributions,
         },
         {
-            name: 'Repo',
+            name: RepoLabel,
             value: userInfo.totalRepositoryContributions,
         },
     ];

--- a/src/create-svg.ts
+++ b/src/create-svg.ts
@@ -94,6 +94,9 @@ export const createSvg = (
         .text(util.inertThousandSeparator(userInfo.totalContributions))
         .attr('fill', settings.strongColor);
 
+    const contribLabel = settings.l10n
+        ? settings.l10n.contrib
+        : 'contributions';
     group
         .append('text')
         .style('font-size', '24px')
@@ -101,7 +104,7 @@ export const createSvg = (
         .attr('y', positionYContrib)
         .attr('text-anchor', 'start')
         .attr('text-anchor', 'start')
-        .text('contributions')
+        .text(contribLabel)
         .attr('fill', settings.foregroundColor);
 
     const positionXStar = (width * 5) / 10;

--- a/src/type.ts
+++ b/src/type.ts
@@ -39,6 +39,15 @@ interface BaseSettings {
     radarColor: string;
 
     fileName?: string;
+
+    l10n?: {
+        commit: string;
+        repo: string;
+        review: string;
+        pullreq: string;
+        issue: string;
+        contrib: string;
+    };
 }
 
 export interface NormalColorSettings extends BaseSettings {


### PR DESCRIPTION
Made it possible to change the label with a custom definition.

See `src/type.ts` and `sample-settings/spanish.json`.

```diff
  {
    "type": "normal",
    "fileName": "profile-custom-spanish.svg",
    "backgroundColor": "#ffffff",
    "foregroundColor": "#00000f",
    "strongColor": "#111133",
    "weakColor": "gray",
    "radarColor": "#47a042",
    "growingAnimation": true,
    "contribColors": [
      "#efefef",
      "#d8e887",
      "#8cc569",
      "#47a042",
      "#1d6a23"
    ],
+   "l10n": {
+     "commit": "Commit",
+     "repo": "Repositorios",
+     "review": "Revisiones",
+     "pullreq": "Pull/Req",
+     "issue": "Issues",
+     "contrib": "contribuciones"
+   }
  }
```