### PR TITLE
fix: growing animation of settings json

### DIFF
--- a/src/create-pie-language.ts
+++ b/src/create-pie-language.ts
@@ -12,7 +12,7 @@ export const createPieLanguage = (
     width: number,
     height: number,
     settings: type.PieLangSettings,
-    isAnimate: boolean
+    isForcedAnimation: boolean
 ): void => {
     if (userInfo.totalContributions === 0) {
         return;
@@ -31,6 +31,7 @@ export const createPieLanguage = (
         });
     }
 
+    const isAnimate = settings.growingAnimation || isForcedAnimation;
     const animeSteps = 5;
     const animateOpacity = (num: number) =>
         Array<string>(languages.length + animeSteps)

--- a/src/create-radar-contrib.ts
+++ b/src/create-radar-contrib.ts
@@ -22,11 +22,13 @@ export const createRadarContrib = (
     width: number,
     height: number,
     settings: type.RadarContribSettings,
-    isAnimate: boolean
+    isForcedAnimation: boolean
 ): void => {
     const radius = (height / 2) * 0.8;
     const cx = width / 2;
     const cy = (height / 2) * 1.1;
+
+    const isAnimate = settings.growingAnimation || isForcedAnimation;
 
     const commitLabel = settings.l10n ? settings.l10n.commit : 'Commit';
     const issueLabel = settings.l10n ? settings.l10n.issue : 'Issue';

--- a/src/type.ts
+++ b/src/type.ts
@@ -37,6 +37,8 @@ export interface RadarContribSettings {
     weakColor: string;
     radarColor: string;
 
+    growingAnimation?: boolean;
+
     fileName?: string;
 
     l10n?: {
@@ -52,6 +54,8 @@ export interface PieLangSettings {
     backgroundColor: string;
     foregroundColor: string;
 
+    growingAnimation?: boolean;
+
     fileName?: string;
 }
 
@@ -61,6 +65,8 @@ export interface BaseSettings extends RadarContribSettings, PieLangSettings {
     strongColor: string;
     weakColor: string;
     radarColor: string;
+
+    growingAnimation?: boolean;
 
     fileName?: string;
 
@@ -76,14 +82,12 @@ export interface BaseSettings extends RadarContribSettings, PieLangSettings {
 
 export interface NormalColorSettings extends BaseSettings {
     type: 'normal';
-    growingAnimation?: boolean;
 
     contribColors: [string, string, string, string, string];
 }
 
 export interface SeasonColorSettings extends BaseSettings {
     type: 'season';
-    growingAnimation?: boolean;
 
     /** first season (Mar. - Jun.) */
     contribColors1: [string, string, string, string, string];
@@ -97,7 +101,6 @@ export interface SeasonColorSettings extends BaseSettings {
 
 export interface RainbowColorSettings extends BaseSettings {
     type: 'rainbow';
-    growingAnimation?: boolean;
 
     saturation: string;
     contribLightness: [string, string, string, string, string];


### PR DESCRIPTION
Fixed animation settings in settings json not being enabled for pie charts and radar charts.