### PR TITLE
Fix variable name cannot start with "GitHub " prefix. #60

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: yoshi389111/github-profile-3d-contrib@0.7.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           USERNAME: ${{ github.repository_owner }}
           SETTING_JSON: conf/github-profile-3d-contrib.json
           
@@ -92,7 +92,7 @@ jobs:
           target_branch: output-3d-contrib
           build_dir: profile-3d-contrib
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 ```
 
 ### 4. Edit `README.md` in your <username> repo, adding the following code:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: yoshi389111/github-profile-3d-contrib@0.7.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           USERNAME: ${{ github.repository_owner }}
       - name: Commit & Push
         run: |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
           git push
 ```
 
-Note: If you also want to include the private repository, register the "personal access token" in the repository and set it to GITHUB_TOKEN specified in the workflow file.
+Note: If you also want to include the private repository, register the "personal access token" in the repository and set it to GH_TOKEN specified in the workflow file.
 
 This will add the action to the repository.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: yoshi389111/github-profile-3d-contrib@0.7.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           USERNAME: ${{ github.repository_owner }}
       - name: Commit & Push
         run: |
@@ -64,7 +64,7 @@ This will add the action to the repository.
 
 #### Environment variables
 
-* `GITHUB_TOKEN` : (required) access token
+* `GH_TOKEN` : (required) access token
 * `USERNAME` : (required) target user name (or specify with an argument).
 * `MAX_REPOS` : (optional) max repositories, default 100 - since ver. 0.2.0
 * `SETTING_JSON` : (optional) settings json file path. See `sample-settings/*.json` and `src/type.ts` in `yoshi389111/github-profile-3d-contrib` repository for details. - since ver. 0.6.0
@@ -136,10 +136,10 @@ e.g.
 
 ## How to use (local)
 
-Set the `GITHUB_TOKEN` environment variable to the value of "personal access token".
+Set the `GH_TOKEN` environment variable to the value of "personal access token".
 
 ```shell-session
-export GITHUB_TOKEN=XXXXXXXXXXXXXXXXXXXXX
+export GH_TOKEN=XXXXXXXXXXXXXXXXXXXXX
 ```
 
 Run it with your GitHub user specified.

--- a/docs/README.es-es.md
+++ b/docs/README.es-es.md
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: yoshi389111/github-profile-3d-contrib@0.7.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           USERNAME: ${{ github.repository_owner }}
       - name: Commit & Push
         run: |
@@ -132,10 +132,10 @@ ej.
 
 ## Cómo usar (local)
 
-Configura la variable de entorno `GITHUB_TOKEN` con el valor del "token de acceso personal".
+Configura la variable de entorno `GH_TOKEN` con el valor del "token de acceso personal".
 
 ```shell-session
-export GITHUB_TOKEN=XXXXXXXXXXXXXXXXXXXXX
+export GH_TOKEN=XXXXXXXXXXXXXXXXXXXXX
 ```
 
 Ejecútelo con su usuario de GitHub especificado.

--- a/docs/README.ja-jp.md
+++ b/docs/README.ja-jp.md
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: yoshi389111/github-profile-3d-contrib@0.7.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           USERNAME: ${{ github.repository_owner }}
       - name: Commit & Push
         run: |
@@ -65,7 +65,7 @@ jobs:
 
 #### 環境変数
 
-* `GITHUB_TOKEN` : (必須) アクセストークン
+* `GH_TOKEN` : (必須) アクセストークン
 * `USERNAME` : (必須) 対象のユーザー名. （あるいは引数で指定する）
 * `MAX_REPOS` : (任意) 最大のリポジトリ数。デフォルトは100 - バージョン 0.2.0 で追加
 * `SETTING_JSON` : (任意) 設定JSONファイルパス。詳細は `yoshi389111/github-profile-3d-contrib` リポジトリの `sample-settings/*.json` や `src/type.ts` を参照してください - バージョン 0.6.0 で追加
@@ -132,10 +132,10 @@ example: git block バージョン
 
 ## 使い方 (ローカル)
 
-環境変数 `GITHUB_TOKEN` には「personal access token」を指定してください。
+環境変数 `GH_TOKEN` には「personal access token」を指定してください。
 
 ```shell-session
-export GITHUB_TOKEN=XXXXXXXXXXXXXXXXXXXXX
+export GH_TOKEN=XXXXXXXXXXXXXXXXXXXXX
 ```
 
 GitHubのユーザを指定して実行してください。

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,9 @@ import * as client from './github-graphql';
 
 export const main = async (): Promise<void> => {
     try {
-        const token = process.env.GITHUB_TOKEN;
+        const token = process.env.GH_TOKEN;
         if (!token) {
-            core.setFailed('GITHUB_TOKEN is empty');
+            core.setFailed('GH_TOKEN is empty');
             return;
         }
         const userName =


### PR DESCRIPTION
renamed GITHUB_TOKEN to GH_TOKEN