### PR TITLE
Added backgroundOpacity option

### DIFF
--- a/src/color-template.ts
+++ b/src/color-template.ts
@@ -3,6 +3,7 @@ import * as type from './type';
 export const NormalSettings: type.NormalColorSettings = {
     type: 'normal',
     backgroundColor: '#ffffff',
+    backgroundOpacity: 1.0,
     foregroundColor: '#00000f',
     strongColor: '#111133',
     weakColor: 'gray',
@@ -13,6 +14,7 @@ export const NormalSettings: type.NormalColorSettings = {
 export const HalloweenSettings: type.NormalColorSettings = {
     type: 'normal',
     backgroundColor: '#ffffff',
+    backgroundOpacity: 1.0,
     foregroundColor: '#00000f',
     strongColor: '#111133',
     weakColor: 'gray',
@@ -24,6 +26,7 @@ export const HalloweenSettings: type.NormalColorSettings = {
 export const NorthSeasonSettings: type.SeasonColorSettings = {
     type: 'season',
     backgroundColor: '#ffffff',
+    backgroundOpacity: 1.0,
     foregroundColor: '#00000f',
     strongColor: '#111133',
     weakColor: 'gray',
@@ -38,6 +41,7 @@ export const NorthSeasonSettings: type.SeasonColorSettings = {
 export const SouthSeasonSettings: type.SeasonColorSettings = {
     type: 'season',
     backgroundColor: '#ffffff',
+    backgroundOpacity: 1.0,
     foregroundColor: '#00000f',
     strongColor: '#111133',
     weakColor: 'gray',
@@ -51,6 +55,7 @@ export const SouthSeasonSettings: type.SeasonColorSettings = {
 export const NightViewSettings: type.NormalColorSettings = {
     type: 'normal',
     backgroundColor: '#00000f',
+    backgroundOpacity: 1.0,
     foregroundColor: '#eeeeff',
     strongColor: 'rgb(255,200,55)',
     weakColor: '#aaaaaa',
@@ -67,6 +72,7 @@ export const NightViewSettings: type.NormalColorSettings = {
 export const NightGreenSettings: type.NormalColorSettings = {
     type: 'normal',
     backgroundColor: '#00000f',
+    backgroundOpacity: 1.0,
     foregroundColor: '#eeeeff',
     strongColor: 'rgb(255,200,55)',
     weakColor: '#aaaaaa',
@@ -77,6 +83,7 @@ export const NightGreenSettings: type.NormalColorSettings = {
 export const NightRainbowSettings: type.RainbowColorSettings = {
     type: 'rainbow',
     backgroundColor: '#00000f',
+    backgroundOpacity: 1.0,
     foregroundColor: '#eeeeff',
     strongColor: 'rgb(255,200,55)',
     weakColor: '#aaaaaa',
@@ -90,6 +97,7 @@ export const NightRainbowSettings: type.RainbowColorSettings = {
 export const GitBlockSettings: type.BitmapPatternSettings = {
     type: 'bitmap',
     backgroundColor: '#ffffff',
+    backgroundOpacity: 1.0,
     foregroundColor: '#00000f',
     strongColor: '#111133',
     weakColor: 'gray',

--- a/src/create-svg.ts
+++ b/src/create-svg.ts
@@ -54,7 +54,8 @@ export const createSvg = (
         .attr('y', 0)
         .attr('width', svgWidth)
         .attr('height', svgHeight)
-        .attr('fill', settings.backgroundColor);
+        .attr('fill', settings.backgroundColor)
+        .attr('fill-opacity', settings.backgroundOpacity);
 
     if (settings.type === 'pie_lang_only') {
         // pie chart only

--- a/src/type.ts
+++ b/src/type.ts
@@ -33,6 +33,7 @@ export type ContributionLevel =
 
 export interface RadarContribSettings {
     backgroundColor: string;
+    backgroundOpacity: number;
     foregroundColor: string;
     weakColor: string;
     radarColor: string;
@@ -52,6 +53,7 @@ export interface RadarContribSettings {
 
 export interface PieLangSettings {
     backgroundColor: string;
+    backgroundOpacity: number;
     foregroundColor: string;
 
     growingAnimation?: boolean;
@@ -62,6 +64,7 @@ export interface PieLangSettings {
 export interface BaseSettings extends RadarContribSettings, PieLangSettings {
     backgroundColor: string;
     foregroundColor: string;
+    backgroundOpacity: number;
     strongColor: string;
     weakColor: string;
     radarColor: string;


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! I'm kind of lazy in terms of pleasing light/dark modes, and usually try to fix with a transparent background, and seemed like I could do that for my own Github Person page.

Anyhow, just wanted to contribute back so here is a PR.

To use add in the following to the JSON. `"backgroundOpacity": 0.0` to make totally transparent and `"backgroundOpacity": 1.0` is solid. 

I know **nothing** about TypeScript , just call me Jon Snow! Hope I did it right by your standards and the PR makes sense.