### PR TITLE
update: support github enterprise

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## xxxx-xx-xx, 0.8.0 release
+
+* Added environment variable `GITHUB_ENDPOINT`.
+
 ## 2025-03-05, 0.7.2 release
 
 * Changed node version from 16 to 20.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This will add the action to the repository.
 * `USERNAME` : (required) target user name (or specify with an argument).
 * `MAX_REPOS` : (optional) max repositories, default 100 - since ver. 0.2.0
 * `SETTING_JSON` : (optional) settings json file path. See `sample-settings/*.json` and `src/type.ts` in `yoshi389111/github-profile-3d-contrib` repository for details. - since ver. 0.6.0
+* `GITHUB_ENDPOINT` : (optional) Github GraphQL endpoint. e.g. `https://github.mycompany.com/api/graphql` - since ver. 0.8.0
 
 ### step 3. Manually launch the action
 

--- a/docs/README.es-es.md
+++ b/docs/README.es-es.md
@@ -69,6 +69,7 @@ Esto agregará la acción al repositorio.
 * `USERNAME` : (requerido) nombre de usuario de destino (o especificar con un argumento).
 * `MAX_REPOS` : (opcional) repositorios máximos, predeterminado 100 - desde ver. 0.2.0
 * `SETTING_JSON` : (opcional) configuración de la ruta del archivo json. Ver `sample-settings/*.json` y `src/type.ts` en `yoshi389111/github-profile-3d-contrib` repositorio para más detalles. - desde ver. 0.6.0
+* `GITHUB_ENDPOINT` : (opcional) endpoint de Github GraphQL. por ejemplo, `https://github.mycompany.com/api/graphql` - desde ver. 0.8.0
 
 ### paso 3. Inicie manualmente la acción
 

--- a/docs/README.ja-jp.md
+++ b/docs/README.ja-jp.md
@@ -70,6 +70,7 @@ jobs:
 * `USERNAME` : (必須) 対象のユーザー名. （あるいは引数で指定する）
 * `MAX_REPOS` : (任意) 最大のリポジトリ数。デフォルトは100 - バージョン 0.2.0 で追加
 * `SETTING_JSON` : (任意) 設定JSONファイルパス。詳細は `yoshi389111/github-profile-3d-contrib` リポジトリの `sample-settings/*.json` や `src/type.ts` を参照してください - バージョン 0.6.0 で追加
+* `GITHUB_ENDPOINT` : (任意) Github GraphQL エンドポイント。 例： `https://github.mycompany.com/api/graphql` - バージョン 0.8.0 で追加
 
 ### 手順 3. アクションを手動起動する
 

--- a/src/github-graphql.ts
+++ b/src/github-graphql.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import * as type from './type';
 
-export const URL = 'https://api.github.com/graphql';
+export const URL = process.env.GITHUB_ENDPOINT || 'https://api.github.com/graphql';
 const maxReposOneQuery = 100;
 
 export type CommitContributionsByRepository = Array<{


### PR DESCRIPTION
- Specify the Github GraphQL endpoint in the environment variable `GITHUB_ENDPOINT`.
- For example, `https://github.mycompany.com/api/graphql`
- The Default is `https://api.github.com/graphql`

fix #89 