### PR TITLE
🔧 Add contents: write permission to enable workflow push

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ on:
     - cron: "0 18 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates the workflow by adding the following:

permissions: contents: write
→ This grants the GitHub Actions bot permission to push commits back to the repository.

Without this explicit permission, workflows using GITHUB_TOKEN cannot perform git push in some cases, especially in newer GitHub repositories with stricter default permissions.

<img width="1329" alt="Screenshot 2025-05-08 at 08 34 48" src="https://github.com/user-attachments/assets/ef0bbcef-be17-41bd-bd16-a96c5fde320f" />
