### PR TITLE
:art: docs: Update language links in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![svg](https://raw.githubusercontent.com/yoshi389111/github-profile-3d-contrib/main/docs/demo/profile-gitblock.svg)
 
 <!-- Language code order (except English) -->
-<!-- [English (en)](README.md) | -->
+English (en) |
 [Deutsch (de)](docs/README.de.md) |
 [Español (es)](docs/README.es.md) |
 [Français (fr)](docs/README.fr.md) |

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -4,6 +4,7 @@
 
 <!-- Sprachreihenfolge (außer Englisch) -->
 [English (en)](../README.md) |
+Deutsch (de) |
 [Español (es)](README.es.md) |
 [Français (fr)](README.fr.md) |
 [日本語 (ja)](README.ja.md) |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -5,6 +5,7 @@
 <!-- Orden del código de idioma (excepto inglés) -->
 [English (en)](../README.md) |
 [Deutsch (de)](README.de.md) |
+Español (es) |
 [Français (fr)](README.fr.md) |
 [日本語 (ja)](README.ja.md) |
 [한국어 (ko)](README.ko.md) |

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -6,6 +6,7 @@
 [English (en)](../README.md) |
 [Deutsch (de)](README.de.md) |
 [Español (es)](README.es.md) |
+Français (fr) |
 [日本語 (ja)](README.ja.md) |
 [한국어 (ko)](README.ko.md) |
 [Português (pt)](README.pt.md) |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -7,6 +7,7 @@
 [Deutsch (de)](README.de.md) |
 [Español (es)](README.es.md) |
 [Français (fr)](README.fr.md) |
+日本語 (ja) |
 [한국어 (ko)](README.ko.md) |
 [Português (pt)](README.pt.md) |
 [Русский (ru)](README.ru.md) |

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -8,6 +8,7 @@
 [Español (es)](README.es.md) |
 [Français (fr)](README.fr.md) |
 [日本語 (ja)](README.ja.md) |
+한국어 (ko) |
 [Português (pt)](README.pt.md) |
 [Русский (ru)](README.ru.md) |
 [简体中文 (zh-CN)](README.zh-CN.md) |

--- a/docs/README.pt.md
+++ b/docs/README.pt.md
@@ -9,6 +9,7 @@
 [Français (fr)](README.fr.md) |
 [日本語 (ja)](README.ja.md) |
 [한국어 (ko)](README.ko.md) |
+Português (pt) |
 [Русский (ru)](README.ru.md) |
 [简体中文 (zh-CN)](README.zh-CN.md) |
 [繁體中文 (zh-TW)](README.zh-TW.md) |

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -10,6 +10,7 @@
 [日本語 (ja)](README.ja.md) |
 [한국어 (ko)](README.ko.md) |
 [Português (pt)](README.pt.md) |
+Русский (ru) |
 [简体中文 (zh-CN)](README.zh-CN.md) |
 [繁體中文 (zh-TW)](README.zh-TW.md) |
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -11,6 +11,7 @@
 [한국어 (ko)](README.ko.md) |
 [Português (pt)](README.pt.md) |
 [Русский (ru)](README.ru.md) |
+简体中文 (zh-CN) |
 [繁體中文 (zh-TW)](README.zh-TW.md) |
 
 > [!NOTE]

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -12,6 +12,7 @@
 [Português (pt)](README.pt.md) |
 [Русский (ru)](README.ru.md) |
 [简体中文 (zh-CN)](README.zh-CN.md) |
+繁體中文 (zh-TW) |
 
 > [!NOTE]
 > 本翻譯由機器自動生成。


### PR DESCRIPTION
This pull request updates the language navigation bars in the main `README.md` and all localized documentation files. The change makes each language's own name appear in the navigation bar, improving clarity and consistency for users browsing documentation in their native language.

Localization improvements:

* Added each language's own name to the navigation bar in its respective localized README file (e.g., `Deutsch (de)` in `README.de.md`, `Español (es)` in `README.es.md`, etc.), making it easier for users to identify the current language. [[1]](diffhunk://#diff-4fc89010b0a19bd0f512b37fa8f9d799233bc7182b9b6e1e141e36235dece89cR7) [[2]](diffhunk://#diff-1a9fe4a98e1061970e4546e2717ee03ff36d2ab8eaaf21b50220244ebadd928dR8) [[3]](diffhunk://#diff-5ad11da1756179e1baf04dee61fec850b999a10e8bb33dd5b5c1f8d28cffa7ceR9) [[4]](diffhunk://#diff-94a285a8a9c55aaa8847e8c887ae9e55ead3037e4d8872845de1c8874a552221R10) [[5]](diffhunk://#diff-34bd30cd1160ddc543664c7d53e34e30d6b3d6fbdce8c587af3d6ba5972ef8cbR11) [[6]](diffhunk://#diff-6dd4e72bdb7ad2330c2c176b05bff10bd9581dd0fba519651da5c1f72f68880aR12) [[7]](diffhunk://#diff-64edd388792add3c0195866b5c42fc985ffaf190cd9d710ee4057f720a7f6a60R13) [[8]](diffhunk://#diff-6336dd9fc5b4f4350f9870c912bf453ca3578905bb60d5d2c0903eb9f64e4764R14) [[9]](diffhunk://#diff-c95695ff962c00a5f807c2bdfe4c0758ef34f92d46608b5c92e8d764c7deb733R15)

Documentation consistency:

* Updated the main `README.md` to display "English (en)" in the language navigation bar, matching the format used in other localized files.