### PR TITLE
:lady_beetle: fix: correctly calculate "week" even when the start date is not Sunday

### DIFF
--- a/src/create-3d-contrib.ts
+++ b/src/create-3d-contrib.ts
@@ -7,8 +7,8 @@ const DARKER_RIGHT = 1;
 const DARKER_LEFT = 0.5;
 const DARKER_TOP = 0;
 
-const diffDate = (beforeDate: number, afterDate: number): number =>
-    Math.floor((afterDate - beforeDate) / (24 * 60 * 60 * 1000));
+const toEpochDays = (date: Date): number =>
+    Math.floor(date.getTime() / (24 * 60 * 60 * 1000));
 
 type PanelType = 'top' | 'left' | 'right';
 
@@ -184,10 +184,13 @@ export const create3DContrib = (
         return;
     }
 
-    const startTime = userInfo.contributionCalendar[0].date.getTime();
+    const firstDate = userInfo.contributionCalendar[0].date;
+    const sundayOfFirstWeek = toEpochDays(firstDate) - firstDate.getUTCDay();
+    const weekcount = Math.ceil(
+        (userInfo.contributionCalendar.length + firstDate.getUTCDay()) / 7.0,
+    );
     const dx = width / 64;
     const dy = dx * Math.tan(ANGLE * ((2 * Math.PI) / 360));
-    const weekcount = Math.ceil(userInfo.contributionCalendar.length / 7.0);
     const dxx = dx * 0.9;
     const dyy = dy * 0.9;
 
@@ -197,8 +200,10 @@ export const create3DContrib = (
     const group = svg.append('g');
 
     userInfo.contributionCalendar.forEach((cal) => {
+        const week = Math.floor(
+            (toEpochDays(cal.date) - sundayOfFirstWeek) / 7,
+        );
         const dayOfWeek = cal.date.getUTCDay(); // sun = 0, mon = 1, ...
-        const week = Math.floor(diffDate(startTime, cal.date.getTime()) / 7);
 
         const baseX = offsetX + (week - dayOfWeek) * dx;
         const baseY = offsetY + (week + dayOfWeek) * dy;


### PR DESCRIPTION
This pull request fixes date calculations in the `create3DContrib` function in `src/create-3d-contrib.ts`, correcting a bug that caused the contribution calendar to display incorrectly when the start date was not a Sunday.

**Logic Fixes**

* The `diffDate` function, which calculates the difference in days between dates, has been replaced with a new `toEpochDays` function, which converts a `Date` to the number of days since the epoch, measured in milliseconds since the epoch.
* The calculations have been corrected to use the Sunday before the start date (`sundayOfFirstWeek`) as the base point, so that the contribution calendar can correctly render weeks even when the start date does not start on a Sunday.
* The number of weeks (rows) to display has been fixed to take into account the day of the week of the start date.