### PR TITLE
fix: add glob flag to rimraf for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node .",
     "dev": "ts-node src/index.ts",
     "dev:watch": "ts-node-dev --respawn src/index.ts",
-    "clean": "rimraf dist/*",
+    "clean": "rimraf --glob dist/*",
     "tsc": "tsc",
     "build": "npm-run-all clean tsc && ncc build dist0/index.js --license licenses.txt",
     "check-types": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node .",
     "dev": "ts-node src/index.ts",
     "dev:watch": "ts-node-dev --respawn src/index.ts",
-    "clean": "rimraf --glob dist/*",
+    "clean": "rimraf --glob 'dist/*'",
     "tsc": "tsc",
     "build": "npm-run-all clean tsc && ncc build dist0/index.js --license licenses.txt",
     "check-types": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node .",
     "dev": "ts-node src/index.ts",
     "dev:watch": "ts-node-dev --respawn src/index.ts",
-    "clean": "rimraf --glob 'dist/*'",
+    "clean": "rimraf --glob \"dist/*\"",
     "tsc": "tsc",
     "build": "npm-run-all clean tsc && ncc build dist0/index.js --license licenses.txt",
     "check-types": "tsc --noEmit",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "sourceMap": true, /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
     "outDir": "./dist0", /* Redirect output structure to the directory. */
-    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
     // "removeComments": true,                      /* Do not emit comments to output. */


### PR DESCRIPTION
This pull request makes a minor update to the `clean` script in `package.json` to ensure compatibility with the latest version of `rimraf` by explicitly specifying the `--glob` flag.

- Updated the `clean` script to use `rimraf --glob 'dist/*'` for compatibility with newer versions of `rimraf`.
  -  #147 cherrypicked