### PR TITLE
feat: add HEIGHT_SCALE option to control 3D block height

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ In the sample, only `GITHUB_TOKEN` and `USERNAME` are specified as environment v
 - `SETTING_JSON` : (optional) settings json file path. See `sample-settings/*.json` and `src/type.ts` in `yoshi389111/github-profile-3d-contrib` repository for details. - since ver. 0.6.0
 - `GITHUB_ENDPOINT` : (optional) Github GraphQL endpoint. For example, if you want to create a contribution calendar based on your company's GitHub Enterprise activity instead of GitHub.com, set this environment variable. e.g. `https://github.mycompany.com/api/graphql` - since ver. 0.8.0
 - `YEAR` : (optional) For past calendars, specify the year. This is intended to be specified when running the tool from the command line. - since ver. 0.8.0
+- `HEIGHT_SCALE` : (optional) divisor controlling the 3D block height, default 20. The block height is `log10(contributions / HEIGHT_SCALE + 1)`, so a smaller value makes blocks taller. Useful if your daily contribution counts are low and the calendar looks flat.
 
 #### About `GITHUB_TOKEN`
 

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -35,5 +35,24 @@ describe('utils', () => {
         expect(util.toScale(1_000_000_000)).toEqual('1M+');
     });
 
+    it('calcBlockHeight', () => {
+        // zero contributions => base height regardless of scale
+        expect(util.calcBlockHeight(0)).toBeCloseTo(3);
+        expect(util.calcBlockHeight(0, 2)).toBeCloseTo(3);
+
+        // omitting heightScale matches the default of 20
+        expect(util.calcBlockHeight(50)).toEqual(util.calcBlockHeight(50, 20));
+
+        // a smaller scale yields taller blocks for the same count
+        expect(util.calcBlockHeight(50, 2)).toBeGreaterThan(
+            util.calcBlockHeight(50, 20),
+        );
+
+        // height increases monotonically with contribution count
+        expect(util.calcBlockHeight(100, 20)).toBeGreaterThan(
+            util.calcBlockHeight(10, 20),
+        );
+    });
+
 });
 

--- a/src/create-3d-contrib.ts
+++ b/src/create-3d-contrib.ts
@@ -172,6 +172,7 @@ export const create3DContrib = (
     height: number,
     settings: type.FullSettings,
     isForcedAnimation = false,
+    heightScale = 20,
 ): void => {
     if (userInfo.contributionCalendar.length === 0) {
         return;
@@ -200,8 +201,10 @@ export const create3DContrib = (
 
         const baseX = offsetX + (week - dayOfWeek) * dx;
         const baseY = offsetY + (week + dayOfWeek) * dy;
-        // ref. https://github.com/yoshi389111/github-profile-3d-contrib/issues/27
-        const calHeight = Math.log10(cal.contributionCount / 20 + 1) * 144 + 3;
+        const calHeight = util.calcBlockHeight(
+            cal.contributionCount,
+            heightScale,
+        );
         const contribLevel = cal.contributionLevel;
 
         const isAnimate = settings.growingAnimation || isForcedAnimation;

--- a/src/create-svg.ts
+++ b/src/create-svg.ts
@@ -21,6 +21,7 @@ export const createSvg = (
     userInfo: type.UserInfo,
     settings: type.Settings,
     isForcedAnimation: boolean,
+    heightScale = 20,
 ): string => {
     let svgWidth = width;
     let svgHeight = height;
@@ -95,6 +96,7 @@ export const createSvg = (
             height,
             settings,
             isForcedAnimation,
+            heightScale,
         );
 
         // radar chart

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,14 @@ export const main = async (): Promise<void> => {
             process.exitCode = 1;
             return;
         }
+        const heightScale = process.env.HEIGHT_SCALE
+            ? Number(process.env.HEIGHT_SCALE)
+            : 20;
+        if (Number.isNaN(heightScale) || heightScale <= 0) {
+            console.error('HEIGHT_SCALE must be a positive number');
+            process.exitCode = 1;
+            return;
+        }
 
         const response = await client.fetchData(
             token,
@@ -52,7 +60,7 @@ export const main = async (): Promise<void> => {
                     settingInfo.fileName || 'profile-customize.svg';
                 f.writeFile(
                     fileName,
-                    create.createSvg(userInfo, settingInfo, false),
+                    create.createSvg(userInfo, settingInfo, false, heightScale),
                 );
             }
         } else {
@@ -62,51 +70,91 @@ export const main = async (): Promise<void> => {
 
             f.writeFile(
                 'profile-green-animate.svg',
-                create.createSvg(userInfo, settings, true),
+                create.createSvg(userInfo, settings, true, heightScale),
             );
             f.writeFile(
                 'profile-green.svg',
-                create.createSvg(userInfo, settings, false),
+                create.createSvg(userInfo, settings, false, heightScale),
             );
 
             // Northern hemisphere
             f.writeFile(
                 'profile-season-animate.svg',
-                create.createSvg(userInfo, template.NorthSeasonSettings, true),
+                create.createSvg(
+                    userInfo,
+                    template.NorthSeasonSettings,
+                    true,
+                    heightScale,
+                ),
             );
             f.writeFile(
                 'profile-season.svg',
-                create.createSvg(userInfo, template.NorthSeasonSettings, false),
+                create.createSvg(
+                    userInfo,
+                    template.NorthSeasonSettings,
+                    false,
+                    heightScale,
+                ),
             );
 
             // Southern hemisphere
             f.writeFile(
                 'profile-south-season-animate.svg',
-                create.createSvg(userInfo, template.SouthSeasonSettings, true),
+                create.createSvg(
+                    userInfo,
+                    template.SouthSeasonSettings,
+                    true,
+                    heightScale,
+                ),
             );
             f.writeFile(
                 'profile-south-season.svg',
-                create.createSvg(userInfo, template.SouthSeasonSettings, false),
+                create.createSvg(
+                    userInfo,
+                    template.SouthSeasonSettings,
+                    false,
+                    heightScale,
+                ),
             );
 
             f.writeFile(
                 'profile-night-view.svg',
-                create.createSvg(userInfo, template.NightViewSettings, true),
+                create.createSvg(
+                    userInfo,
+                    template.NightViewSettings,
+                    true,
+                    heightScale,
+                ),
             );
 
             f.writeFile(
                 'profile-night-green.svg',
-                create.createSvg(userInfo, template.NightGreenSettings, true),
+                create.createSvg(
+                    userInfo,
+                    template.NightGreenSettings,
+                    true,
+                    heightScale,
+                ),
             );
 
             f.writeFile(
                 'profile-night-rainbow.svg',
-                create.createSvg(userInfo, template.NightRainbowSettings, true),
+                create.createSvg(
+                    userInfo,
+                    template.NightRainbowSettings,
+                    true,
+                    heightScale,
+                ),
             );
 
             f.writeFile(
                 'profile-gitblock.svg',
-                create.createSvg(userInfo, template.GitBlockSettings, true),
+                create.createSvg(
+                    userInfo,
+                    template.GitBlockSettings,
+                    true,
+                    heightScale,
+                ),
             );
         }
     } catch (error) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,3 +27,18 @@ export const toScale = (value: number): string => {
 
 /** Round to two decimal places. */
 export const toFixed = (value: number): number => +value.toFixed(2);
+
+/**
+ * Calculate the 3D block height for a day's contribution count.
+ *
+ * `heightScale` is the divisor in the logarithmic curve; a smaller value
+ * makes blocks taller, which is useful when daily contribution counts are
+ * low and the calendar otherwise looks flat. The default of 20 keeps the
+ * original appearance.
+ *
+ * ref. https://github.com/yoshi389111/github-profile-3d-contrib/issues/27
+ */
+export const calcBlockHeight = (
+    contributionCount: number,
+    heightScale = 20,
+): number => Math.log10(contributionCount / heightScale + 1) * 144 + 3;


### PR DESCRIPTION
## Summary

Adds an optional `HEIGHT_SCALE` environment variable that controls the divisor in the 3D block-height formula (`log10(contributions / HEIGHT_SCALE + 1)`). Default is `20`, so existing output is unchanged. A smaller value makes blocks taller, which helps accounts with low daily contribution counts whose calendars otherwise look flat.

Closes #159.

## Changes

- Read and validate `HEIGHT_SCALE` in `index.ts`, consistent with `MAX_REPOS`/`YEAR`.
- Extract the height calculation into `util.calcBlockHeight(count, heightScale)` and thread the value through `createSvg` → `create3DContrib`.
- Add a unit test for `calcBlockHeight`.
- Document `HEIGHT_SCALE` in the README.

## Notes

`dist/` is intentionally not included, since it's regenerated by the "Build and Commit" workflow. Locally verified: `npm run lint`, `npm test` (11/11), and the `ncc` bundle all pass.