### PR TITLE
feat: optional INCLUDE_ORGS env var to count org-owned repos in star/fork totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ In the sample, only `GITHUB_TOKEN` and `USERNAME` are specified as environment v
 - `SETTING_JSON` : (optional) settings json file path. See `sample-settings/*.json` and `src/type.ts` in `yoshi389111/github-profile-3d-contrib` repository for details. - since ver. 0.6.0
 - `GITHUB_ENDPOINT` : (optional) Github GraphQL endpoint. For example, if you want to create a contribution calendar based on your company's GitHub Enterprise activity instead of GitHub.com, set this environment variable. e.g. `https://github.mycompany.com/api/graphql` - since ver. 0.8.0
 - `YEAR` : (optional) For past calendars, specify the year. This is intended to be specified when running the tool from the command line. - since ver. 0.8.0
+- `INCLUDE_ORGS` : (optional) Comma-separated list of organization logins whose public repositories should also be counted toward the star/fork totals. Useful when most of your work lives inside an organization rather than under your personal account. Default: empty (unchanged behavior). Example: `INCLUDE_ORGS: my-org,other-org`
 
 #### About `GITHUB_TOKEN`
 

--- a/src/github-graphql.ts
+++ b/src/github-graphql.ts
@@ -180,12 +180,59 @@ export const fetchNext = async (
     return response.data;
 };
 
+export type OrgResponseType = {
+    data?: {
+        organization: {
+            repositories: Repositories;
+        } | null;
+    };
+    errors?: [
+        {
+            message: string;
+        },
+    ];
+};
+
+export const fetchOrgRepos = async (
+    token: string,
+    orgLogin: string,
+    cursor: string | null = null,
+): Promise<OrgResponseType> => {
+    const headers = {
+        Authorization: `bearer ${token}`,
+    };
+    const after = cursor ? `, after: "${cursor}"` : '';
+    const request = {
+        query: `
+            query($login: String!) {
+                organization(login: $login) {
+                    repositories(first: ${maxReposOneQuery}${after}, isFork: false, privacy: PUBLIC) {
+                        edges {
+                            cursor
+                        }
+                        nodes {
+                            forkCount
+                            stargazerCount
+                        }
+                    }
+                }
+            }
+        `.replace(/\s+/g, ' '),
+        variables: { login: orgLogin },
+    };
+    const response = await axios.post<OrgResponseType>(URL, request, {
+        headers: headers,
+    });
+    return response.data;
+};
+
 /** Fetch data from GitHub GraphQL */
 export const fetchData = async (
     token: string,
     userName: string,
     maxRepos: number,
     year: number | null = null,
+    includeOrgs: ReadonlyArray<string> = [],
 ): Promise<ResponseType> => {
     const res1 = await fetchFirst(token, userName, year);
     const result = res1.data;
@@ -207,5 +254,32 @@ export const fetchData = async (
             }
         }
     }
+
+    if (result && includeOrgs.length > 0) {
+        for (const org of includeOrgs) {
+            let cursor: string | null = null;
+            let done = false;
+            while (!done) {
+                const orgRes: OrgResponseType = await fetchOrgRepos(
+                    token,
+                    org,
+                    cursor,
+                );
+                const orgRepos = orgRes.data?.organization?.repositories;
+                if (!orgRepos || orgRepos.nodes.length === 0) {
+                    done = true;
+                } else {
+                    result.user.repositories.nodes.push(...orgRepos.nodes);
+                    if (orgRepos.nodes.length !== maxReposOneQuery) {
+                        done = true;
+                    } else {
+                        cursor =
+                            orgRepos.edges[orgRepos.edges.length - 1].cursor;
+                    }
+                }
+            }
+        }
+    }
+
     return res1;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,11 +35,17 @@ export const main = async (): Promise<void> => {
             return;
         }
 
+        const includeOrgs = (process.env.INCLUDE_ORGS || '')
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+
         const response = await client.fetchData(
             token,
             userName,
             maxRepos,
             year,
+            includeOrgs,
         );
         const userInfo = aggregate.aggregateUserInfo(response);
 


### PR DESCRIPTION
## What

Adds an opt-in `INCLUDE_ORGS` environment variable that lets a user fold the public repositories owned by named GitHub organizations into the star and fork totals shown on the generated SVG.

- `INCLUDE_ORGS` is a comma-separated list of org logins (e.g. `INCLUDE_ORGS: my-org,other-org`)
- When unset or empty, behavior is **identical to today** — no change for existing users
- Org-repo pagination follows the same shape as the existing user-repo pagination
- No new token scope required: only public org repos are queried

## Why

The current GraphQL query is hard-coded to `ownerAffiliations: OWNER`:

https://github.com/yoshi389111/github-profile-3d-contrib/blob/main/src/github-graphql.ts#L127

That's the right default — "show my stars on my repos" is what most users want, and it keeps the count unambiguous. But it has one common failure mode: a lot of people do most of their open-source work **inside an organization** (a company GitHub org, a project they co-founded, or a multi-maintainer collaboration). For those users, the SVG's star/fork badge reads near-empty even when their org repos have thousands of stars, because none of those repos are owned by their personal account.

Concrete example from my own profile:

| | personal repos only | with `INCLUDE_ORGS=pmxt-dev` |
|---|---|---|
| ⭐ stars  | 190   | 2,142 |
| 🍴 forks  | 46    | 280   |

The 190/46 isn't *wrong* — it's an accurate count of repos I personally own — but it misses the work I'd actually want to point someone at. Most of my public footprint lives in `pmxt-dev/pmxt` (1.9k⭐), not in personal scratch repos. Same shape for anyone whose work lives in an org.

I considered a few alternatives before landing here:

1. **Auto-include every org the user is a member of.** Rejected. A user might be a passive member of many orgs they didn't actually contribute to (e.g. `read:org`-scoped collaborations), and silently bundling those into "your stars" would be misleading.
2. **Add `ORGANIZATION_MEMBER` to `ownerAffiliations`.** Same problem — it pulls in every org you're a member of, with no way to scope it.
3. **Opt-in list of org logins.** ← this PR. The user explicitly names the orgs they identify with, so the semantic stays honest, the default behavior is unchanged, and there's no risk of accidentally inflating someone's numbers.

## Implementation

Two-file change:

- `src/github-graphql.ts`: adds `fetchOrgRepos()` that queries `organization(login).repositories(first:100, isFork:false, privacy:PUBLIC)` paginated the same way as the user query, and merges nodes into `result.user.repositories.nodes` so the existing aggregation in `aggregate-user-info.ts` continues to work unchanged.
- `src/index.ts`: parses `INCLUDE_ORGS` from env and threads it into `fetchData`.
- `README.md`: documents the new env var.

The merge into `user.repositories.nodes` is deliberate — it keeps every downstream consumer (aggregation, language pie, etc.) working with no other code changes. Org repos contribute their `stargazerCount` and `forkCount` only; the language/contribution stats are still computed off the user-centric `contributionsCollection` that the action already fetches.

## Testing

- Existing test suite passes locally (`npm test`: 5 suites, 10 tests, all green)
- Lint clean (`npm run lint`)
- Ran the action locally against my own GitHub account both with and without `INCLUDE_ORGS` to confirm:
  - Empty/unset → identical output to current `main`
  - Set → org repos correctly merged, totals match the sum of stars/forks across the named orgs

## Compatibility

- Default behavior unchanged
- No new GraphQL scope or permissions required
- No breaking changes to the function signature visible to callers — `fetchData`'s new `includeOrgs` parameter has a `[]` default